### PR TITLE
Differentiate invalid from non-connected gids

### DIFF
--- a/spec_synapse_v2.md
+++ b/spec_synapse_v2.md
@@ -506,7 +506,16 @@ SYN2 files MUST define two attributes for file format versionning
     * dataset size : 2x1
     * value "[ 1, 0 ]"
 
+### Neuron ID range (Min & Max gid)
 
+SYN2 files MUST specify the lowest and highest GIDs in the dataset. They serve the main purposes of identifying out-of-range Gids out of  gids without connectivity, even in the absence of any index.
+
+"/synapses/{population_name}#gid_range
+
+    * associated elent : "/synapses/{population_name}"
+    * key : "gid_range"
+    * datatype : "INT64"
+    * dataset size : 2x1
 
 
 # SCALE CONSIDERATIONS


### PR DESCRIPTION
Added a little metadata information (gid min & max) that enables to differentiate between invalid and non-connected gids.